### PR TITLE
Validate header value in AddResponseFromClaims

### DIFF
--- a/OCP.Msal.Proxy.Web/Controllers/AuthController.cs
+++ b/OCP.Msal.Proxy.Web/Controllers/AuthController.cs
@@ -108,8 +108,13 @@ namespace OCP.Msal.Proxy.Web.Controllers
                 var claimName = claim.Type;
                 if (claimName.Contains("/")) claimName = claimName.Split('/')[claimName.Split('/').Length - 1];
                 var name = $"X-Injected-{claimName}";
-                if (!headers.ContainsKey(name)) headers.Add(name, claim.Value);
+                if (!headers.ContainsKey(name) && IsValidHeaderValue(claim.Value)) headers.Add(name, claim.Value);
             }
+        }
+
+        internal static bool IsValidHeaderValue(string value)
+        {
+            return value.All(c => c >= 32 && c < 127);
         }
     }
 }


### PR DESCRIPTION
Kestrel doesn't allow non-ascii characters in header values.
It throws InvalidOperationException if a header value contains non-ascii char.
This issue happens only with Kestrel because it has a different implementation of IHeaderDictionary.