### PR TITLE
Update Nginx and cert manager configuration

### DIFF
--- a/AutomationScripts/2-ingressCreation.sh
+++ b/AutomationScripts/2-ingressCreation.sh
@@ -4,7 +4,7 @@ echo "BEGIN @ $(date +"%T"): Installing the ingress controller..."
 kubectl create ns ingress-controllers
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
-helm install nginx-ingress ingress-nginx/ingress-nginx --namespace ingress-controllers --set rbac.create=true --set controller.config.large-client-header-buffers="8 32k"
+helm install nginx-ingress ingress-nginx/ingress-nginx --namespace ingress-controllers --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz --set rbac.create=true --set controller.config.large-client-header-buffers="8 32k"
 
 INGRESS_IP=$(kubectl get services/nginx-ingress-ingress-nginx-controller -n ingress-controllers -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
 

--- a/AutomationScripts/4-installCertManager.sh
+++ b/AutomationScripts/4-installCertManager.sh
@@ -16,7 +16,6 @@ helm repo update
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.3.1 \
   --set installCRDs=true \
   --set ingressShim.defaultIssuerName=letsencrypt-prod \
   --set ingressShim.defaultIssuerKind=ClusterIssuer


### PR DESCRIPTION
- Updated nginx health probe conig. Nginx health probe path was set to "/" instead of "/healthz" in updated helm chart which breaks AKS versions >1.24. The docs on the MS Learn have been updated to reflect that. [GitHub Issue](https://github.com/Azure/AKS/issues/2955 )
- Removed specific version of cert manager and let's script install default 