### PR TITLE
Fix: updated git fetch depth for versioning

### DIFF
--- a/.github/workflows/Prod.yml
+++ b/.github/workflows/Prod.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Calculate new version number
       id: versionNum


### PR DESCRIPTION
- Git checkout only checks out the last 2 commits so if the previous commit doesn't have a version it can fail